### PR TITLE
Add image to answers on IRMA polls

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -2359,10 +2359,23 @@ footer {
       position: absolute;
     }
 
+    img {
+      border: 2px solid #fff;
+      border-radius: rem-calc(12);
+      margin-bottom: $line-height / 2;
+    }
+
     input:checked + label {
-      background: $brand;
-      border: 2px solid $brand !important;
-      color: #fff !important;
+
+      .button {
+        background: $brand;
+        border: 2px solid $brand !important;
+        color: #fff !important;
+      }
+
+      img {
+        border: 2px solid $brand;
+      }
 
       &::after {
         background: $brand;
@@ -2371,11 +2384,14 @@ footer {
         content: "\6c";
         color: #fff;
         font-family: "icons" !important;
-        font-size: rem-calc(12);
-        padding: $line-height / 4;
+        font-size: rem-calc(14);
+        height: 30px;
+        padding-left: $line-height / 4;
+        padding-top: 1px;
         position: absolute;
-        right: -8px;
-        top: -12px;
+        right: 6px;
+        top: -6px;
+        width: 30px;
       }
     }
 

--- a/app/views/polls/questions/_answers_irma.html.erb
+++ b/app/views/polls/questions/_answers_irma.html.erb
@@ -1,9 +1,16 @@
 <div class="poll-question-answers irma">
   <% question.question_answers.each do |answer| %>
-    <div class="relative">
+    <div class="relative small-12 medium-6 column end">
       <input type="radio" class="button-check" name="answers_question_<%= question.id %>"
              id="answer_<%= answer.id %>" value="<%= answer.title %>">
-      <label for="answer_<%= answer.id %>" class="button secondary hollow "><%= answer.title %></label><br>
+      <label for="answer_<%= answer.id %>">
+        <% if answer.images.any? %>
+          <% image = answer.images.first %>
+          <%= image_tag image.attachment.url(:original), class: "orbit-image",
+                        title: image.title.unicode_normalize, alt: image.title.unicode_normalize %>
+        <% end %>
+        <span class="button secondary hollow"><%= answer.title %></span>
+      </label><br>
     </div>
   <% end %>
 </div>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -59,8 +59,10 @@
               <h3><%= answer.title %></h3>
             <% end %>
 
-            <% if answer.images.any? %>
-              <%= render "gallery", answer: answer %>
+            <% unless @poll.irma? %>
+              <% if answer.images.any? %>
+                <%= render "gallery", answer: answer %>
+              <% end %>
             <% end %>
 
             <% if answer.description.present? %>

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -323,6 +323,28 @@ describe "Polls" do
       end
     end
 
+    scenario "IRMA polls show only first image with the answers and hide gallery" do
+      poll = create(:poll, :irma)
+      question = create(:poll_question, poll: poll)
+      answer_1 = create(:poll_question_answer, title: "Answer 1", question: question, description: "One image")
+      answer_2 = create(:poll_question_answer, title: "Answer 2", question: question, description: "Two images")
+      image_1 = create(:image, imageable: answer_1, title: "Title for image one")
+      image_2 = create(:image, imageable: answer_2, title: "Title for image two")
+      image_3 = create(:image, imageable: answer_2, title: "Title for image three")
+
+      visit poll_path(poll)
+
+      within(".poll-question-answers") do
+        expect(page).to have_selector("img", count: 2)
+        expect(page).to have_css("img[alt='#{image_1.title}']")
+        expect(page).to have_css("img[alt='#{image_2.title}']")
+        expect(page).not_to have_css("img[alt='#{image_3.title}']")
+      end
+
+      expect(page).not_to have_selector "#answer_#{answer_1.id}_gallery"
+      expect(page).not_to have_selector "#answer_#{answer_2.id}_gallery"
+    end
+
     scenario "Non-logged in users" do
       create(:poll_question, :yes_no, poll: poll)
 


### PR DESCRIPTION
## Objectives

Add the first image to answers on IRMA polls and hide gallery.

## Visual Changes

![irma_answer_images](https://user-images.githubusercontent.com/631897/112637089-12d50900-8e3e-11eb-9d11-ecde66cb57ca.png)

